### PR TITLE
Fix repo inconsistencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24'
       - name: Build
         run: go build -v ./...
       - name: Test
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24'
       - name: Build binaries
         run: |
           GOOS=linux GOARCH=amd64 go build -o terraform-ansible-inventory-linux

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Go
         uses: actions/setup-go@v5
-        with: { go-version: '1.22' }
+        with: { go-version: '1.24' }
       - name: Run unit tests
         run: go test -v ./...
       - name: Smoke test

--- a/README.md
+++ b/README.md
@@ -98,5 +98,5 @@ terraform-ansible-inventory \
 
 ## 📄 License
 
-MIT © Nick von Podewils
+Apache-2.0 © Nick von Podewils
 


### PR DESCRIPTION
## Summary
- update license reference in README to match Apache-2.0 LICENSE
- align Go version in CI workflows with go.mod
- ensure newline at EOF in test workflow

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_684ff8dbb9048325ac729fc5589bca50