### PR TITLE
Add docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A high-performance, zero-dependency Go command-line tool for extracting Ansible host definitions from deeply nested Terraform state (or any large JSON), and emitting them in various formats (JSON, INI, TXT, or native Ansible inventory).
 
+For extensive usage guides see the [docs directory](docs/) which also powers the GitHub Pages site.
+
 ---
 
 ## 🔍 Features

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,3 @@
+remote_theme: pages-themes/cayman@v0.2.0
+plugins:
+- jekyll-remote-theme

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,13 @@
+# Advanced Configuration
+
+The CLI allows overriding JSON paths for hostnames and IP addresses.
+
+```bash
+terraform-ansible-inventory \
+  --input state.json \
+  --format ansible \
+  --host-field "values.custom_hostname" \
+  --ip-field "values.vars.primary_ip"
+```
+
+Use this when your Terraform state stores host information under custom keys.

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,8 @@
+# Features
+
+- **Streaming JSON parsing** for huge files without high memory use.
+- Supports output formats: `json`, `ini`, `txt` and native Ansible inventory.
+- Extract hostnames and IPs via configurable dot-path flags.
+- Strips CIDR suffixes automatically when generating inventories.
+- Clean CLI interface with sensible defaults.
+- Includes a smoke test JSON example and CI workflow.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,11 @@
+# Terraform Ansible Inventory Documentation
+
+Welcome to the documentation site for **terraform-ansible-inventory**.
+
+This site provides detailed instructions for installing, using and extending the CLI.
+
+- [Features](features.md)
+- [Installation](installation.md)
+- [Usage](usage.md)
+- [Advanced Configuration](advanced.md)
+

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,20 @@
+# Installation
+
+1. Clone the repository:
+
+```bash
+git clone https://github.com/HilkopterBob/terraform-ansible-inventory.git
+cd terraform-ansible-inventory
+```
+
+2. Build the binary:
+
+```bash
+go build -o terraform-ansible-inventory ./main.go
+```
+
+3. (Optional) Install globally:
+
+```bash
+go install github.com/HilkopterBob/terraform-ansible-inventory@latest
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,23 @@
+# Usage
+
+Run the executable with `--help` to see all options:
+
+```bash
+terraform-ansible-inventory --help
+```
+
+Example commands:
+
+```bash
+# Emit raw JSON of all ansible_host objects
+terraform-ansible-inventory -i state.json -f json > hosts.json
+
+# Generate INI style inventory
+terraform-ansible-inventory -i state.json -f ini > hosts.ini
+
+# Plain text dump
+terraform-ansible-inventory -i state.json -f txt > hosts.txt
+
+# Native Ansible inventory
+terraform-ansible-inventory -i state.json -f ansible
+```


### PR DESCRIPTION
## Summary
- add docs site in `docs/` for GitHub Pages
- link to documentation from README

## Testing
- `go test ./...`
- `go build -o terraform-ansible-inventory ./main.go`
- `./terraform-ansible-inventory -i smoketest.json -f ansible`

------
https://chatgpt.com/codex/tasks/task_b_684ff93c47f48325a0b0ad3d90fed967