### PR TITLE
Fix smoke test path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,5 +21,5 @@ jobs:
       - name: Smoke test
         run: |
           echo 'Running smoke test...'
-          terraform-ansible-inventory -i smoketest.json -f ansible \
+          ./terraform-ansible-inventory -i smoketest.json -f ansible \
             | grep -q "test1 ansible_host=192.168.1.10"


### PR DESCRIPTION
## Summary
- ensure smoke test executes the binary from repo path

## Testing
- `go test ./...`
- `go build -o terraform-ansible-inventory`
- `./terraform-ansible-inventory -i smoketest.json -f ansible`

------
https://chatgpt.com/codex/tasks/task_b_684ffc7554c083259d84a0e1dbd16221