### PR TITLE
Add TODO notes for provider parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ For extensive usage guides see the [docs directory](docs/) which also powers the
 - **Built-in IP/CIDR handling**: Strips CIDR suffix for `ansible_host` variables.
 - **Clean CLI interface**: Automatic `--help` message, sensible defaults.
 - **CI/CD ready**: Smoke-test JSON example and GitHub Actions for build & test.
+- **TODO**: Update documentation once full provider feature set and new output
+  formats are implemented.
 
 ---
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -11,3 +11,6 @@ terraform-ansible-inventory \
 ```
 
 Use this when your Terraform state stores host information under custom keys.
+
+<!-- TODO: document provider-specific options like host groups and inventory
+level variables when implemented -->

--- a/docs/features.md
+++ b/docs/features.md
@@ -6,3 +6,5 @@
 - Strips CIDR suffixes automatically when generating inventories.
 - Clean CLI interface with sensible defaults.
 - Includes a smoke test JSON example and CI workflow.
+- **TODO:** Describe upcoming support for all provider resources and improved
+  YAML/INI export once implemented.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,3 +9,6 @@ This site provides detailed instructions for installing, using and extending the
 - [Usage](usage.md)
 - [Advanced Configuration](advanced.md)
 
+<!-- TODO: Expand docs with examples covering host groups and advanced
+inventory features once rework is complete. -->
+

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,3 +18,6 @@ go build -o terraform-ansible-inventory ./main.go
 ```bash
 go install github.com/HilkopterBob/terraform-ansible-inventory@latest
 ```
+
+<!-- TODO: Update installation instructions once the CLI includes new
+dependencies or build steps. -->

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -21,3 +21,6 @@ terraform-ansible-inventory -i state.json -f txt > hosts.txt
 # Native Ansible inventory
 terraform-ansible-inventory -i state.json -f ansible
 ```
+
+<!-- TODO: document new filtering flags and extended provider support when
+available -->

--- a/internal/inventory/inventory.go
+++ b/internal/inventory/inventory.go
@@ -7,6 +7,10 @@ type Inventory struct {
 	Groups map[string]*Group
 }
 
+// TODO: The provider exposes additional fields (like inventory level vars and
+// host group relationships) that are not currently represented here. Extend
+// this structure accordingly.
+
 type Host struct {
 	Name      string
 	Variables map[string]string
@@ -48,6 +52,8 @@ func (inv *Inventory) AddHost(h *Host) {
 		grp := inv.Groups[g]
 		grp.Hosts = append(grp.Hosts, h.Name)
 	}
+	// TODO: Support additional host attributes provided by the Terraform
+	// provider, such as enabled/disabled state and arbitrary metadata.
 }
 
 // AddGroup adds or updates a group.
@@ -60,6 +66,8 @@ func (inv *Inventory) AddGroup(g *Group) {
 	for _, child := range g.Children {
 		inv.ensureGroup(child)
 	}
+	// TODO: Group attributes like parents defined via separate resources
+	// should be merged here when parsing newer provider versions.
 }
 
 func (inv *Inventory) ensureGroup(name string) *Group {

--- a/internal/iohandler/inventory_output.go
+++ b/internal/iohandler/inventory_output.go
@@ -18,6 +18,8 @@ type groupYAML struct {
 
 // OutputInventory dispatches YAML or INI inventory output.
 func OutputInventory(inv *inventory.Inventory, format string) error {
+	// TODO: Add export formats that mirror Ansible's inventory plugins and
+	// ensure parity with the provider's data model.
 	switch format {
 	case "json":
 		return outputJSONInventory(inv)
@@ -35,6 +37,10 @@ func outputYAML(inv *inventory.Inventory) error {
 		Hosts:    make(map[string]any),
 		Children: make(map[string]*groupYAML),
 	}
+
+	// TODO: Review this structure against Ansible's YAML inventory
+	// specification. The current output may not cover all supported
+	// attributes like group-level vars or nested hostvars.
 
 	// add hosts
 	for _, h := range inv.Hosts {
@@ -124,6 +130,9 @@ func index(s string, c byte) int {
 func outputINIInventory(inv *inventory.Inventory) error {
 	var out string
 
+	// TODO: Rework INI generation to produce valid Ansible inventory
+	// syntax including group nesting and host variable sections.
+
 	groups := make([]string, 0, len(inv.Groups))
 	for name := range inv.Groups {
 		groups = append(groups, name)
@@ -179,6 +188,8 @@ func formatHostINI(h *inventory.Host) string {
 		}
 		line += fmt.Sprintf(" %s=%s", k, v)
 	}
+	// TODO: include all supported host parameters from the provider when
+	// formatting the INI entry.
 	return line
 }
 

--- a/internal/parser/inventory.go
+++ b/internal/parser/inventory.go
@@ -7,6 +7,12 @@ import (
 	"github.com/buger/jsonparser"
 )
 
+// TODO: Expand parsing logic to cover all resources exposed by the
+// ansible/ansible Terraform provider. This currently only understands
+// ansible_host and ansible_group, but the provider includes additional
+// resources such as group membership and inventory level variables that
+// should be reflected in the Inventory structure.
+
 // ParseInventory walks the Terraform state JSON and extracts all ansible_host
 // and ansible_group resources, returning a structured Inventory.
 func ParseInventory(data []byte) *inventory.Inventory {
@@ -19,6 +25,8 @@ func ParseInventory(data []byte) *inventory.Inventory {
 
 		// Determine if this object is a resource we care about
 		if t, err := jsonparser.GetString(current, "type"); err == nil {
+			// TODO: Handle additional resource types emitted by the
+			// Terraform provider once they are added.
 			switch t {
 			case "ansible_host":
 				var tmp struct {

--- a/main.go
+++ b/main.go
@@ -20,6 +20,9 @@ func main() {
 		Usage:     "Generate an Ansible inventory from a Terraform state produced by the ansible/ansible provider",
 		Version:   version,
 		ArgsUsage: "--input <file> [--format yaml|ini|json]",
+		// TODO: Add CLI flags for filtering hosts/groups and for
+		// selecting output formats like YAML or INI according to the
+		// full capabilities of the ansible/ansible provider.
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "input",
@@ -53,6 +56,9 @@ func main() {
 
 			// 3) Dispatch output
 			format := strings.ToLower(c.String("format"))
+			// TODO: support additional output styles (e.g. split
+			// inventories by group) once provider parity is
+			// implemented.
 			return iohandler.OutputInventory(inv, format)
 		},
 		CustomAppHelpTemplate: `{{.Name}} {{.Version}}


### PR DESCRIPTION
## Summary
- insert TODO markers for extending parser to additional ansible provider resources
- annotate inventory data structures for future features
- mark YAML and INI writers for improved ansible compatibility
- note upcoming CLI and documentation updates

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_684ffcc816c88325bf623e8b6bb252df