### PR TITLE
Add GitLab friendly container

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,35 @@
+name: Docker Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/terraform-ansible-inventory:${{ github.ref_name }}
+            ghcr.io/${{ github.repository_owner }}/terraform-ansible-inventory:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.24-alpine AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o terraform-ansible-inventory
+
+FROM alpine:3.19
+COPY --from=builder /src/terraform-ansible-inventory /usr/local/bin/terraform-ansible-inventory
+ENTRYPOINT ["terraform-ansible-inventory"]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,29 @@ go install github.com/HilkopterBob/terraform-ansible-inventory@latest
 [releases page](https://github.com/HilkopterBob/terraform-ansible-inventory/releases).
 ```
 
+### Docker image
+
+A small container image is published for each release on
+[GitHub Container Registry](https://ghcr.io).
+Run it like any other command line tool or inside CI pipelines:
+
+```bash
+docker run --rm ghcr.io/HilkopterBob/terraform-ansible-inventory:latest --help
+```
+
+In GitLab CI you must override the image entrypoint so the pipeline script can
+run:
+
+```yaml
+image:
+  name: ghcr.io/HilkopterBob/terraform-ansible-inventory:latest
+  entrypoint: [""]
+
+generate-inventory:
+  script:
+    - terraform-ansible-inventory --input tf.json --format yaml > inventory.yaml
+```
+
 ---
 
 ## 🚀 Usage


### PR DESCRIPTION
## Summary
- use `alpine` runtime instead of `scratch` to provide a shell
- document how to run the container in GitLab CI

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68511bb2f0a08325a9a7e59d9d28d52d