### PR TITLE
Add streaming JSON parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ RedHat's official inventory plugin struggles with nested modules and often misse
 
 ## 🔍 Features
 
-- **Streaming JSON parsing** for huge state files without high memory use.
+ - **Streaming JSON parsing** for huge state files without high memory use using the `jstream` library.
 - **Multiple output formats**: `yaml`, `ini`, `json` and native Ansible inventory.
 - **Understands provider resources** including host variables and group hierarchy.
 - **Child module aware** so nested modules are fully traversed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ your state file, this tool can consume it and output Ansible formatted data.
 
 ## Features
 
-- **Streaming JSON parsing** for huge state files without high memory use.
+- **Streaming JSON parsing** for huge state files without high memory use using the `jstream` library.
 - **Multiple output formats**: `yaml`, `ini`, `json` and native Ansible
   inventory.
 - **Understands provider resources**: host variables, group hierarchy and

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/HilkopterBob/terraform-ansible-inventory
 go 1.24.1
 
 require (
-	github.com/buger/jsonparser v1.1.1
+	github.com/bcicen/jstream v1.0.1
 	github.com/urfave/cli/v2 v2.27.7
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
-github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/bcicen/jstream v1.0.1 h1:BXY7Cu4rdmc0rhyTVyT3UkxAiX3bnLpKLas9btbH5ck=
+github.com/bcicen/jstream v1.0.1/go.mod h1:9ielPxqFry7Y4Tg3j4BfjPocfJ3TbsRtXOAYXYmRuAQ=
 github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
 github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
@@ -8,6 +8,7 @@ github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
 github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/parser/filter.go
+++ b/internal/parser/filter.go
@@ -1,54 +1,42 @@
 package parser
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 
-	"github.com/buger/jsonparser"
+	"github.com/bcicen/jstream"
 )
 
 // ExtractAnsibleHosts finds any JSON object at any depth with
-// "type":"ansible_host". It traverses both objects and arrays using a
-// breadth-first search so that results are returned in the same order as they
-// appear in the input. It always returns a non-nil slice (so even if nothing
-// matches, you get "[]" not "null").
+// "type":"ansible_host". The returned slice is never nil even when no
+// matches are found.
 func ExtractAnsibleHosts(data []byte) []map[string]interface{} {
-	// Pre-allocate empty slice so JSON-encoding yields [] not null
+	return ExtractAnsibleHostsReader(bytes.NewReader(data))
+}
+
+// ExtractAnsibleHostsReader streams JSON from r and returns all objects where
+// "type" == "ansible_host". The returned slice is never nil.
+func ExtractAnsibleHostsReader(r io.Reader) []map[string]interface{} {
 	results := make([]map[string]interface{}, 0, 4)
+	dec := jstream.NewDecoder(r, -1)
 
-	// Queue for BFS: start by enqueuing the root blob
-	queue := [][]byte{data}
-
-	for len(queue) > 0 {
-		// Dequeue
-		current := queue[0]
-		queue = queue[1:]
-
-		// --- 1) Check this node itself for type=="ansible_host"
-		if t, err := jsonparser.GetString(current, "type"); err == nil && t == "ansible_host" {
-			var obj map[string]interface{}
-			if err := json.Unmarshal(current, &obj); err == nil {
-				results = append(results, obj)
+	for mv := range dec.Stream() {
+		if mv.ValueType != jstream.Object {
+			continue
+		}
+		obj, ok := mv.Value.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if t, _ := obj["type"].(string); t == "ansible_host" {
+			// copy so callers can modify without affecting parser state
+			buf, _ := json.Marshal(obj)
+			var out map[string]interface{}
+			if err := json.Unmarshal(buf, &out); err == nil {
+				results = append(results, out)
 			}
 		}
-
-		// --- 2) Recurse into any child *objects*
-		jsonparser.ObjectEach(current, func(_ []byte, val []byte, dt jsonparser.ValueType, _ int) error {
-			// If the field value is an object or an array, push it
-			if dt == jsonparser.Object || dt == jsonparser.Array {
-				queue = append(queue, val)
-			}
-			return nil
-		})
-
-		// --- 3) Recurse into any child *array* elements
-		jsonparser.ArrayEach(current, func(val []byte, dt jsonparser.ValueType, _ int, err error) {
-			if err != nil {
-				return
-			}
-			if dt == jsonparser.Object || dt == jsonparser.Array {
-				queue = append(queue, val)
-			}
-		})
 	}
 
 	return results

--- a/internal/parser/filter_test.go
+++ b/internal/parser/filter_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"bytes"
 	"encoding/json"
 	"reflect"
 	"testing"
@@ -79,5 +80,13 @@ func TestExtractAnsibleHostsNone(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Fatalf("expected 0 hosts, got %d", len(got))
+	}
+}
+
+func TestExtractAnsibleHostsReader(t *testing.T) {
+	data := []byte(`{"type":"ansible_host","values":{"name":"r1"}}`)
+	res := ExtractAnsibleHostsReader(bytes.NewReader(data))
+	if len(res) != 1 {
+		t.Fatalf("expected 1 host, got %d", len(res))
 	}
 }

--- a/internal/parser/inventory_test.go
+++ b/internal/parser/inventory_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 )
@@ -45,5 +46,19 @@ func TestParseInventory(t *testing.T) {
 	}
 	if h, ok := inv.Hosts["host1"]; !ok || h.Variables["ip"] != "10.0.0.1" {
 		t.Fatalf("host parse failed")
+	}
+}
+
+func TestParseInventoryReader(t *testing.T) {
+	state := map[string]any{
+		"type": "ansible_inventory",
+		"values": map[string]any{
+			"variables": map[string]string{"env": "test"},
+		},
+	}
+	buf, _ := json.Marshal(state)
+	inv := ParseInventoryReader(bytes.NewReader(buf))
+	if inv.Vars["env"] != "test" {
+		t.Fatalf("inventory vars not parsed")
 	}
 }


### PR DESCRIPTION
## Summary
- rework JSON parsing using `jstream` to avoid loading entire state into memory
- add reader-based parsing helpers and update tests
- document the streaming parser in README and docs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_6851803ab2c883258c3a9f2b9e56a7fc