### PR TITLE
Fix INI filter duplication and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ RedHat's official inventory plugin struggles with nested modules and often misse
 ## 🔍 Features
 
 - **Streaming JSON parsing** for huge state files without high memory use using the `jstream` library.
-- **Multiple output formats**: `yaml`, `ini`, `json` and native Ansible inventory.
+ - **Multiple output formats**: `yaml`, `ini`, and `json`.
 - **Understands provider resources** including host variables and group hierarchy.
 - **Child module aware** so nested modules are fully traversed.
 - **Built-in IP/CIDR handling** for `ansible_host` variables.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,8 +22,7 @@ your state file, this tool can consume it and output Ansible formatted data.
 ## Features
 
 - **Streaming JSON parsing** for huge state files without high memory use using the `jstream` library.
-- **Multiple output formats**: `yaml`, `ini`, `json` and native Ansible
-  inventory.
+- **Multiple output formats**: `yaml`, `ini`, and `json`.
 - **Understands provider resources**: host variables, group hierarchy and
   inventory level variables from the `ansible/ansible` provider.
 - **Child module aware**: traverses nested modules to pick up all resources.
@@ -192,22 +191,6 @@ tier=frontend
 
 You can restrict output to specific hosts or groups using the `--host` and
 `--group` flags. Multiple values are allowed.
-
-## Advanced configuration
-
-You can override the JSON paths for hostnames and IP addresses if your state
-uses custom keys:
-
-```bash
-terraform-ansible-inventory \
-  --input state.json \
-  --format ansible \
-  --host-field "values.custom_hostname" \
-  --ip-field "values.vars.primary_ip"
-```
-
-Inventory-level variables and group resources emitted by the provider are
-automatically detected and included in the generated inventory.
 
 ## Contributing
 

--- a/internal/inventory/inventory.go
+++ b/internal/inventory/inventory.go
@@ -51,7 +51,11 @@ func (inv *Inventory) AddHost(h *Host) {
 		for k, v := range h.Variables {
 			existing.Variables[k] = v
 		}
-		existing.Groups = append(existing.Groups, h.Groups...)
+		for _, g := range h.Groups {
+			if !contains(existing.Groups, g) {
+				existing.Groups = append(existing.Groups, g)
+			}
+		}
 		if h.Metadata != nil {
 			if existing.Metadata == nil {
 				existing.Metadata = make(map[string]string)
@@ -76,7 +80,9 @@ func (inv *Inventory) AddHost(h *Host) {
 	for _, g := range h.Groups {
 		inv.ensureGroup(g)
 		grp := inv.Groups[g]
-		grp.Hosts = append(grp.Hosts, h.Name)
+		if !contains(grp.Hosts, h.Name) {
+			grp.Hosts = append(grp.Hosts, h.Name)
+		}
 	}
 }
 
@@ -86,12 +92,24 @@ func (inv *Inventory) AddGroup(g *Group) {
 	for k, v := range g.Variables {
 		grp.Variables[k] = v
 	}
-	grp.Children = append(grp.Children, g.Children...)
+	for _, child := range g.Children {
+		if !contains(grp.Children, child) {
+			grp.Children = append(grp.Children, child)
+		}
+	}
 	for _, child := range g.Children {
 		inv.ensureGroup(child)
 	}
-	grp.Parents = append(grp.Parents, g.Parents...)
-	grp.Hosts = append(grp.Hosts, g.Hosts...)
+	for _, p := range g.Parents {
+		if !contains(grp.Parents, p) {
+			grp.Parents = append(grp.Parents, p)
+		}
+	}
+	for _, hname := range g.Hosts {
+		if !contains(grp.Hosts, hname) {
+			grp.Hosts = append(grp.Hosts, hname)
+		}
+	}
 	for _, h := range g.Hosts {
 		if host, ok := inv.Hosts[h]; ok {
 			if !contains(host.Groups, g.Name) {

--- a/internal/iohandler/filter_duplicate_test.go
+++ b/internal/iohandler/filter_duplicate_test.go
@@ -1,0 +1,24 @@
+package iohandler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/HilkopterBob/terraform-ansible-inventory/internal/inventory"
+)
+
+func TestINIFilterNoDuplicates(t *testing.T) {
+	inv := inventory.New()
+	inv.AddHost(&inventory.Host{Name: "h1", Groups: []string{"web"}, Variables: map[string]string{"ip": "1.2.3.4"}})
+	inv.AddGroup(&inventory.Group{Name: "web", Hosts: []string{"h1"}})
+
+	inv = inv.CopyFiltered([]string{"h1"}, nil)
+	out, err := captureOutput(func() error { return OutputInventory(inv, "ini") })
+	if err != nil {
+		t.Fatalf("ini output error: %v", err)
+	}
+	count := strings.Count(out, "h1 ansible_host=1.2.3.4")
+	if count != 1 {
+		t.Fatalf("expected 1 host entry, got %d: \n%s", count, out)
+	}
+}


### PR DESCRIPTION
## Summary
- avoid duplicate host entries when filtering
- add a regression test to ensure INI filtering doesn't duplicate hosts
- remove mentions of unsupported features from docs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_6851aa35f3fc83258a9b83947227b95d