### PR TITLE
Add CLI integration tests and clean helpers

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func runCLI(t *testing.T, stdin string, args ...string) (string, error) {
+	cmdArgs := append([]string{"run", "main.go"}, args...)
+	cmd := exec.Command("go", cmdArgs...)
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func TestCLIMissingInput(t *testing.T) {
+	out, err := runCLI(t, "")
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(out, "Required flag \"input\" not set") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}
+
+func TestCLIInvalidFormat(t *testing.T) {
+	out, err := runCLI(t, "", "--input", "smoketest.json", "--format", "bad")
+	if err == nil {
+		t.Fatalf("expected error for bad format")
+	}
+	if !strings.Contains(out, "unknown inventory format") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}
+
+func TestCLIReadStdin(t *testing.T) {
+	data, err := os.ReadFile("smoketest.json")
+	if err != nil {
+		t.Fatalf("read smoketest: %v", err)
+	}
+	out, err := runCLI(t, string(data), "--input", "-", "--format", "ini")
+	if err != nil {
+		t.Fatalf("cli run err: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "[web]") || !strings.Contains(out, "ansible_host=192.168.1.10") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}

--- a/internal/inventory/inventory_test.go
+++ b/internal/inventory/inventory_test.go
@@ -119,3 +119,26 @@ func TestAddGroupCreatesHosts(t *testing.T) {
 		t.Fatalf("child group not created")
 	}
 }
+func TestMergeGroupHostDuplicatesEdge(t *testing.T) {
+	inv := New()
+	inv.AddGroup(&Group{Name: "dup", Hosts: []string{"h1", "h1"}})
+	if len(inv.Groups["dup"].Hosts) != 1 {
+		t.Fatalf("expected deduplicated host list, got %v", inv.Groups["dup"].Hosts)
+	}
+	inv.AddHost(&Host{Name: "h1", Groups: []string{"dup", "dup"}})
+	if len(inv.Hosts["h1"].Groups) != 1 {
+		t.Fatalf("expected deduplicated group list on host, got %v", inv.Hosts["h1"].Groups)
+	}
+}
+
+func TestAddHostInvalidName(t *testing.T) {
+	inv := New()
+	inv.AddHost(&Host{Name: "", Groups: []string{"web"}})
+	if _, ok := inv.Hosts[""]; !ok {
+		t.Fatalf("host with empty name not present")
+	}
+	inv.AddHost(&Host{Name: "", Groups: []string{"web"}})
+	if len(inv.Groups["web"].Hosts) != 1 {
+		t.Fatalf("expected deduped empty host in group, got %v", inv.Groups["web"].Hosts)
+	}
+}

--- a/internal/iohandler/inventory_output.go
+++ b/internal/iohandler/inventory_output.go
@@ -127,10 +127,8 @@ func ensureGroupYAML(root *groupYAML, name string) *groupYAML {
 }
 
 func stripCIDR(ip string) string {
-	if idx := len(ip); idx > 0 {
-		if pos := index(ip, '/'); pos >= 0 {
-			return ip[:pos]
-		}
+	if pos := index(ip, '/'); pos >= 0 {
+		return ip[:pos]
 	}
 	return ip
 }


### PR DESCRIPTION
## Summary
- add CLI integration tests
- test inventory merging edge cases with duplicate or empty host names
- simplify `stripCIDR` helper

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_68524b9179208325beea6738171d4a43