### PR TITLE
Handle JSON parse errors

### DIFF
--- a/internal/parser/inventory.go
+++ b/internal/parser/inventory.go
@@ -14,14 +14,14 @@ import (
 
 // ParseInventory walks the Terraform state JSON and extracts all ansible_host
 // and ansible_group resources, returning a structured Inventory.
-func ParseInventory(data []byte) *inventory.Inventory {
+func ParseInventory(data []byte) (*inventory.Inventory, error) {
 	return ParseInventoryReader(bytes.NewReader(data))
 }
 
 // ParseInventoryReader streams Terraform state JSON from r and extracts
 // ansible_* resources to build an inventory compatible with the
 // ansible/ansible provider.
-func ParseInventoryReader(r io.Reader) *inventory.Inventory {
+func ParseInventoryReader(r io.Reader) (*inventory.Inventory, error) {
 	inv := inventory.New()
 	dec := jstream.NewDecoder(r, -1)
 
@@ -58,7 +58,11 @@ func ParseInventoryReader(r io.Reader) *inventory.Inventory {
 		}
 	}
 
-	return inv
+	if err := dec.Err(); err != nil {
+		return nil, err
+	}
+
+	return inv, nil
 }
 
 func getString(v interface{}) string {

--- a/internal/parser/inventory_test.go
+++ b/internal/parser/inventory_test.go
@@ -37,7 +37,10 @@ func TestParseInventory(t *testing.T) {
 		},
 	}
 	buf, _ := json.Marshal(state)
-	inv := ParseInventory(buf)
+	inv, err := ParseInventory(buf)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
 	if inv.Vars["env"] != "test" {
 		t.Fatalf("inventory vars not parsed")
 	}
@@ -88,7 +91,10 @@ func TestParseGroupChildrenParents(t *testing.T) {
 		},
 	}
 	buf, _ := json.Marshal(state)
-	inv := ParseInventory(buf)
+	inv, err := ParseInventory(buf)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
 	c, ok := inv.Groups["child"]
 	if !ok {
 		t.Fatalf("child group missing")
@@ -110,9 +116,9 @@ func TestParseGroupChildrenParents(t *testing.T) {
 	}
 	if _, ok := inv.Hosts["h2"]; !ok {
 		t.Fatalf("host h2 from grand child missing")
-  }
+	}
 }
-    
+
 func TestParseInventoryReader(t *testing.T) {
 	state := map[string]any{
 		"type": "ansible_inventory",
@@ -121,8 +127,18 @@ func TestParseInventoryReader(t *testing.T) {
 		},
 	}
 	buf, _ := json.Marshal(state)
-	inv := ParseInventoryReader(bytes.NewReader(buf))
+	inv, err := ParseInventoryReader(bytes.NewReader(buf))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
 	if inv.Vars["env"] != "test" {
 		t.Fatalf("inventory vars not parsed")
+	}
+}
+
+func TestParseInventoryReaderMalformed(t *testing.T) {
+	data := []byte("{invalid}")
+	if _, err := ParseInventoryReader(bytes.NewReader(data)); err == nil {
+		t.Fatal("expected error for malformed JSON")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -57,7 +57,10 @@ func main() {
 			}
 
 			// 2) Parse inventory from Terraform state
-			inv := parser.ParseInventory(data)
+			inv, err := parser.ParseInventory(data)
+			if err != nil {
+				return err
+			}
 
 			// 3) Apply filters
 			hosts := c.StringSlice("host")


### PR DESCRIPTION
## Summary
- propagate errors from `ParseInventoryReader`
- adjust CLI for new return type
- extend tests for malformed JSON

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68524c93c9308325a06b9be06fcc97bf