### PR TITLE
Parse enabled and metadata in ansible_host

### DIFF
--- a/internal/parser/inventory.go
+++ b/internal/parser/inventory.go
@@ -42,6 +42,8 @@ func ParseInventoryReader(r io.Reader) *inventory.Inventory {
 				Name:      getString(values["name"]),
 				Groups:    toStringSlice(values["groups"]),
 				Variables: toStringMap(values["variables"]),
+				Metadata:  toStringMap(values["metadata"]),
+				Enabled:   getBool(values["enabled"]),
 			}
 			inv.AddHost(h)
 		case "ansible_group":
@@ -94,4 +96,11 @@ func toStringMap(v interface{}) map[string]string {
 		}
 	}
 	return out
+}
+
+func getBool(v interface{}) bool {
+	if b, ok := v.(bool); ok {
+		return b
+	}
+	return false
 }

--- a/internal/parser/inventory_test.go
+++ b/internal/parser/inventory_test.go
@@ -110,9 +110,9 @@ func TestParseGroupChildrenParents(t *testing.T) {
 	}
 	if _, ok := inv.Hosts["h2"]; !ok {
 		t.Fatalf("host h2 from grand child missing")
-  }
+	}
 }
-    
+
 func TestParseInventoryReader(t *testing.T) {
 	state := map[string]any{
 		"type": "ansible_inventory",
@@ -124,5 +124,36 @@ func TestParseInventoryReader(t *testing.T) {
 	inv := ParseInventoryReader(bytes.NewReader(buf))
 	if inv.Vars["env"] != "test" {
 		t.Fatalf("inventory vars not parsed")
+	}
+}
+
+func TestParseHostMetadataEnabled(t *testing.T) {
+	state := map[string]any{
+		"values": map[string]any{
+			"root_module": map[string]any{
+				"resources": []any{
+					map[string]any{
+						"type": "ansible_host",
+						"values": map[string]any{
+							"name":     "h1",
+							"enabled":  true,
+							"metadata": map[string]any{"role": "db"},
+						},
+					},
+				},
+			},
+		},
+	}
+	buf, _ := json.Marshal(state)
+	inv := ParseInventory(buf)
+	h, ok := inv.Hosts["h1"]
+	if !ok {
+		t.Fatalf("host missing")
+	}
+	if !h.Enabled {
+		t.Fatalf("enabled flag not parsed")
+	}
+	if h.Metadata["role"] != "db" {
+		t.Fatalf("metadata not parsed: %#v", h.Metadata)
 	}
 }


### PR DESCRIPTION
## Summary
- parse `enabled` and `metadata` fields from `ansible_host`
- add regression test verifying parsing of these fields

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68524c8a2dd48325adb20ad104803402