### PR TITLE
Fix default enabled state

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ all:
 env=prod
 
 [web]
-test1 ansible_host=192.168.1.10 os=linux ansible_disabled=true
+test1 ansible_host=192.168.1.10 os=linux
 
 [web:vars]
 tier=frontend
@@ -179,7 +179,7 @@ tier=frontend
         "os": "linux"
       },
       "Groups": ["web"],
-      "Enabled": false,
+      "Enabled": true,
       "Metadata": {}
     }
   },

--- a/docs/index.md
+++ b/docs/index.md
@@ -153,7 +153,7 @@ all:
 env=prod
 
 [web]
-test1 ansible_host=192.168.1.10 os=linux ansible_disabled=true
+test1 ansible_host=192.168.1.10 os=linux
 
 [web:vars]
 tier=frontend
@@ -171,7 +171,7 @@ tier=frontend
         "os": "linux"
       },
       "Groups": ["web"],
-      "Enabled": false,
+      "Enabled": true,
       "Metadata": {}
     }
   },

--- a/internal/parser/inventory.go
+++ b/internal/parser/inventory.go
@@ -42,6 +42,10 @@ func ParseInventoryReader(r io.Reader) (*inventory.Inventory, error) {
 				Name:      getString(values["name"]),
 				Groups:    toStringSlice(values["groups"]),
 				Variables: toStringMap(values["variables"]),
+				Enabled:   true,
+			}
+			if en, ok := values["enabled"].(bool); ok {
+				h.Enabled = en
 			}
 			inv.AddHost(h)
 		case "ansible_group":


### PR DESCRIPTION
## Summary
- parse `enabled` attribute from host resources and default to `true`
- update examples to show hosts enabled by default

## Testing
- `go test ./...`
- `go run . --input smoketest.json --format ini`

------
https://chatgpt.com/codex/tasks/task_b_6852717362f88325a7df60083a151011