### PR TITLE
Add terraform-enabled Docker image

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -36,3 +36,14 @@ jobs:
           tags: |
             ghcr.io/hilkopterbob/terraform-ansible-inventory:${{ github.ref_name }}
             ghcr.io/hilkopterbob/terraform-ansible-inventory:latest
+      - name: Build and push image with Terraform
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          target: terraform
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/hilkopterbob/terraform-ansible-inventory:${{ github.ref_name }}-tf
+            ghcr.io/hilkopterbob/terraform-ansible-inventory:latest-tf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,14 @@ jobs:
           grep -q "ansible_host=192.168.1.10" out.ini
           docker run --rm -v $PWD:/data -w /data tfi:test -i smoketest.json -f json > out.json
           grep -q '"test1"' out.json
+      - name: Build Docker image with Terraform
+        run: docker build -t tfi:terraform --target terraform .
+      - name: Smoke test Terraform Docker image
+        run: |
+          echo 'Running Terraform Docker smoke test...'
+          docker run --rm -v $PWD:/data -w /data tfi:terraform -i smoketest.json -f yaml > out.yml
+          grep -q "test1" out.yml
+          docker run --rm -v $PWD:/data -w /data tfi:terraform -i smoketest.json -f ini > out.ini
+          grep -q "ansible_host=192.168.1.10" out.ini
+          docker run --rm -v $PWD:/data -w /data tfi:terraform -i smoketest.json -f json > out.json
+          grep -q '"test1"' out.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,14 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o terraform-ansible-inventory
 
-FROM alpine:3.19
+FROM alpine:3.19 AS runtime
+RUN apk add --no-cache git curl vim
 COPY --from=builder /src/terraform-ansible-inventory /usr/local/bin/terraform-ansible-inventory
 ENTRYPOINT ["terraform-ansible-inventory"]
+
+FROM runtime AS terraform
+RUN apk add --no-cache unzip \
+    && TF_VERSION=$(curl -fsSL https://checkpoint-api.hashicorp.com/v1/check/terraform | grep -o '"current_version":"[^"]*"' | cut -d '"' -f4) \
+    && wget -q https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip -O /tmp/terraform.zip \
+    && unzip /tmp/terraform.zip -d /usr/local/bin \
+    && rm /tmp/terraform.zip

--- a/README.md
+++ b/README.md
@@ -51,12 +51,18 @@ go install github.com/HilkopterBob/terraform-ansible-inventory@latest
 
 ### Docker image
 
-A small container image is published for each release on
+Two container images are published for each release on
 [GitHub Container Registry](https://ghcr.io).
-Run it like any other command line tool or inside CI pipelines:
+`terraform-ansible-inventory` is a minimal runtime image while the `-tf` variant
+also bundles the latest Terraform binary. Use the latter when you need to pull
+state from remote backends.
 
 ```bash
+# minimal image
 docker run --rm ghcr.io/hilkopterbob/terraform-ansible-inventory:latest --help
+
+# with Terraform installed
+docker run --rm ghcr.io/hilkopterbob/terraform-ansible-inventory:latest-tf terraform version
 ```
 
 In GitLab CI you must override the image entrypoint so the pipeline script can

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,12 +52,17 @@ Download the latest release if you prefer not to build the binary yourself.
 
 ### Docker image
 
-A small container image is published for each release on
-[GitHub Container Registry](https://ghcr.io). Run it like any other command line
-tool or inside CI pipelines:
+Two container images are published on
+[GitHub Container Registry](https://ghcr.io). `terraform-ansible-inventory`
+contains only the inventory binary while the `-tf` tag additionally installs the
+latest Terraform release. Use the `-tf` variant when accessing remote state.
 
 ```bash
+# minimal image
 docker run --rm ghcr.io/HilkopterBob/terraform-ansible-inventory:latest --help
+
+# with Terraform installed
+docker run --rm ghcr.io/HilkopterBob/terraform-ansible-inventory:latest-tf terraform version
 ```
 
 In GitLab CI you must override the image entrypoint so the pipeline script can


### PR DESCRIPTION
## Summary
- add git, curl, and vim to runtime image
- create `terraform` build stage that installs the latest Terraform release
- document the new `-tf` image variant
- push both images in Docker release workflow
- test new image in CI workflow

## Testing
- `go test ./...`
- `go build -o terraform-ansible-inventory`
- ❌ `docker build` *(failed: docker not found)*

------
https://chatgpt.com/codex/tasks/task_b_685ba92ee638832586fd6d0498e15754